### PR TITLE
Move the parent/child theme logic into the file fetcher

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -15,28 +15,28 @@ namespace Kalutara\Helpers;
  */
 function get_files_in_path( $dir ) {
 	$result = [];
-	$directories = [];
+	$directories = [
+		get_template_directory(),
+	];
 
 	if ( is_child_theme() ) {
 		$directories[] = get_stylesheet_directory();
 	}
 
-	$directories[] = get_template_directory();
-
 	foreach ( $directories as $directory ) {
-		foreach ( scandir( $directory . '/' . $dir ) as $filename ) {
-			if ( basename( $filename )[0] === '.' ) {
+		foreach ( scandir( $directory . '/' . $dir ) as $top_slug => $top_filename ) {
+			if ( basename( $top_filename )[0] === '.' ) {
 				continue;
 			}
 
-			$basename = $dir . '/' . $filename;
+			$basename = $dir . '/' . $top_filename;
 
 			if ( is_dir( $directory . '/' . $basename ) ) {
-				foreach ( get_files_in_path( $basename ) as $child_file_name ) {
-					$result[] = $child_file_name;
+				foreach ( get_files_in_path( $basename ) as $child_slug => $child_filename ) {
+					$result[ $child_slug ] = $child_filename;
 				}
 			} else {
-				$result[] = $basename;
+				$result[ $basename ] = $directory . '/' . $basename;
 			}
 		}
 	}

--- a/inc/templates/pattern-library.php
+++ b/inc/templates/pattern-library.php
@@ -22,9 +22,9 @@ $query = new \WP_Query( [
 while ( $query->have_posts() ) :
 	$query->the_post();
 
-	foreach ( Helpers\get_files_in_path( 'template-parts' ) as $file ) : ?>
-		<article class="kalutara-component <?php echo esc_attr( Helpers\get_css_class_name( $file ) ); ?>">
-			<strong><?php echo esc_html( $file ); ?></strong>
+	foreach ( Helpers\get_files_in_path( 'template-parts' ) as $slug => $file ) : ?>
+		<article class="kalutara-component <?php echo esc_attr( Helpers\get_css_class_name( $slug ) ); ?>">
+			<strong><?php echo esc_html( $slug ); ?></strong>
 			<?php
 
 			if ( ! empty( $file_documentation['summary'] ) ) :
@@ -47,9 +47,12 @@ while ( $query->have_posts() ) :
 			<div class="kalutara-component__preview">
 				<?php
 				get_extended_template_part(
-					Helpers\remove_extension_from_filename( $file ),
+					Helpers\remove_extension_from_filename( $slug ),
 					'',
-					Data\get_data( $file_path )
+					Data\get_data( $file ),
+					[
+						'dir' => '/'
+					]
 				);
 				?>
 			</div>


### PR DESCRIPTION
This means that a parent/child theme setup is always supported regardless of whether the pattern library template gets overridden.