### PR TITLE
Support displaying multiple variants for a template part

### DIFF
--- a/inc/data.php
+++ b/inc/data.php
@@ -25,3 +25,15 @@ function get_data( $file ) {
 		$file_documentation['data_providers']
 	);
 }
+
+/**
+ * Get a value from the _meta array in a template data object.
+ *
+ * @param string $value Key of a meta key to retrieve.
+ * @return mixed Value of the meta key specified.
+ */
+function get_meta_value( $file, $value ) {
+	$data = get_data( $file );
+
+	return $data['_meta'][ $value ] ?? null;
+}

--- a/inc/parser.php
+++ b/inc/parser.php
@@ -22,8 +22,12 @@ function get_template_part_header( $file ) {
 
 	$has_header = preg_match( '#/\*\*(.|[\n\r])*?\*/#m', $template_part, $matches );
 
+	// Return bare default values if the file has no header.
 	if ( ! $has_header ) {
-		return;
+		return [
+			'data' => [ [ '_meta' => [] ] ],
+			'data_providers' => [],
+		];
 	}
 
 	$reflector_factory = DocBlockFactory::createInstance();
@@ -53,7 +57,7 @@ function parse_data( $data ) {
 	return array_map(
 		function ( $data_entry ) {
 			$data_value = $data_entry->getDescription()->render();
-			return json_decode( $data_value );
+			return json_decode( $data_value, true );
 		},
 		$data
 	);

--- a/inc/templates/pattern-library.php
+++ b/inc/templates/pattern-library.php
@@ -44,15 +44,29 @@ foreach ( $directories as $directory ) :
 			endif;
 			?>
 
-			<div class="kalutara-component__preview">
-				<?php
-				get_extended_template_part(
-					Helpers\remove_extension_from_filename( $file ),
-					'',
-					Data\get_data( $file_path )
-				);
-				?>
-			</div>
+			<?php
+				$data_objects = Data\get_data( $file_path );
+
+				foreach ( $data_objects as $data ) :
+
+					// If this data variant has a "title" in its meta, output that.
+					if ( ! empty( $data['_meta']['title'] ) ) {
+						echo '<h6 class="kalutara-component__variant-title">' . esc_html( $data['_meta']['title'] ) . '</h6>';
+
+					}
+					?>
+					<div class="kalutara-component__preview">
+						<?php
+						get_extended_template_part(
+							Helpers\remove_extension_from_filename( $file ),
+							'',
+							$data
+						);
+						?>
+					</div>
+					<?php
+				endforeach;
+			?>
 		</article>
 		<?php
 	endforeach;


### PR DESCRIPTION
Allows multiple data entries to be registered for a template part through the header comments. Any entries included in @data or @dataProvider tags will be merged together and used to display different variants.

(If a header is present but no data tag is provided, the template part will not render. If no header is present, the template part will render once with an empty data array (ie, just making use of global values from the latest post on the site.)