### PR TITLE
Use core get_template_part with filter to use extended templates

### DIFF
--- a/inc/parser.php
+++ b/inc/parser.php
@@ -36,12 +36,6 @@ function get_template_part_header( $file ) {
 		'documentation' => $parsed->getDescription()->render(),
 		'template_vars' => $parsed->getTagsByName( 'var', null, true ),
 		'globals'       => $parsed->getTagsByName( 'global', null, true ),
-		// Should this template use the extended template part function to load?
-		'is_extended_template' => apply_filters(
-			'kalutara_is_extended_template',
-			! empty( $parsed->getTagsByName( 'isExtendedTemplatePart' ) ),
-			$file,
-		),
 		'data' => array_merge(
 			parse_data(
 				$parsed->getTagsByName( 'data', null, true )

--- a/inc/parser.php
+++ b/inc/parser.php
@@ -32,11 +32,17 @@ function get_template_part_header( $file ) {
 	$parsed = $reflector_factory->create( $matches[0] );
 
 	return [
-		'summary'        => $parsed->getSummary(),
-		'documentation'  => $parsed->getDescription()->render(),
-		'template_vars'  => $parsed->getTagsByName( 'var', null, true ),
-		'globals'        => $parsed->getTagsByName( 'global', null, true ),
-		'data'           => array_merge(
+		'summary'       => $parsed->getSummary(),
+		'documentation' => $parsed->getDescription()->render(),
+		'template_vars' => $parsed->getTagsByName( 'var', null, true ),
+		'globals'       => $parsed->getTagsByName( 'global', null, true ),
+		// Should this template use the extended template part function to load?
+		'is_extended_template' => apply_filters(
+			'kalutara_is_extended_template',
+			! empty( $parsed->getTagsByName( 'isExtendedTemplatePart' ) ),
+			$file,
+		),
+		'data' => array_merge(
 			parse_data(
 				$parsed->getTagsByName( 'data', null, true )
 			),

--- a/inc/templates/pattern-library.php
+++ b/inc/templates/pattern-library.php
@@ -47,7 +47,6 @@ foreach ( $directories as $directory ) :
 			$variations = ! empty( $file_documentation['data'] ) ? $file_documentation['data'] : [ [] ];
 
 			foreach ( $variations as $data ) :
-
 				// If this data variant has a "title" in its meta, output that.
 				if ( ! empty( $data['_meta']['title'] ) ) {
 					echo '<h4 class="kalutara-component__variant-title">' . esc_html( $data['_meta']['title'] ) . '</h4>';
@@ -56,11 +55,17 @@ foreach ( $directories as $directory ) :
 				?>
 				<div class="kalutara-component__preview">
 					<?php
-					get_extended_template_part(
-						Kalutara\Helpers\remove_extension_from_filename( $file ),
-						'',
-						$data
-					);
+					$template = Kalutara\Helpers\remove_extension_from_filename( $file );
+
+					if ( isset( $file_documentation['is_extended_template'] ) && $file_documentation['is_extended_template'] ) {
+						if ( ! function_exists( 'get_extended_template_part' ) ) {
+							wp_die( 'get_extended_template_part plugin not found.' );
+						}
+
+						get_extended_template_part( $template, '', $data );
+					} else {
+						get_template_part( 'template-parts/' . $template, '', $data );
+					}
 					?>
 				</div>
 				<?php

--- a/inc/templates/pattern-library.php
+++ b/inc/templates/pattern-library.php
@@ -56,8 +56,10 @@ foreach ( $directories as $directory ) :
 				<div class="kalutara-component__preview">
 					<?php
 					$template = Kalutara\Helpers\remove_extension_from_filename( $file );
+					$is_extended_template_part = apply_filters( 'kalutara_use_extended_template_parts', false, $file );
 
-					if ( isset( $file_documentation['is_extended_template'] ) && $file_documentation['is_extended_template'] ) {
+					if ( $is_extended_template_part ) {
+						// Handle extended template parts plugin not enabled.
 						if ( ! function_exists( 'get_extended_template_part' ) ) {
 							wp_die( 'get_extended_template_part plugin not found.' );
 						}


### PR DESCRIPTION
Default to the WordPress core template part loading functionality. `get_template_part`.

But you can specify using `get_extended_template_part` instead using a filter. 

This is pretty basic but works OK for now. I think allowing users to filter the function is overcomplicating it a bit as the data that needs to be passed will be different, so it's not so trivial to do this.