### PR TITLE
Handle single pattern template

### DIFF
--- a/inc/rewrites.php
+++ b/inc/rewrites.php
@@ -10,7 +10,7 @@ const QUERY_VAR = 'kalutara';
  *
  * @return void
  */
-function setup()  {
+function setup() {
 	add_action( 'init', __NAMESPACE__ . '\\setup_rewrite_rules' );
 	add_filter( 'query_vars', __NAMESPACE__ . '\\setup_query_vars' );
 	add_action( 'template_redirect', __NAMESPACE__ . '\\template_redirect' );
@@ -21,7 +21,7 @@ function setup()  {
  *
  * @return void
  */
-function setup_rewrite_rules()  {
+function setup_rewrite_rules() {
 	add_rewrite_rule( '^' . SLUG . '\/?$', 'index.php?' . QUERY_VAR . '=all', 'top' );
 	add_rewrite_rule( '^' . SLUG . '\/(.+)?$', 'index.php?' . QUERY_VAR . '=$matches[1]', 'top' );
 }
@@ -29,7 +29,8 @@ function setup_rewrite_rules()  {
 /**
  * Setup Query Vars.
  *
- * @return void
+ * @param array $query_vars Query vars.
+ * @return array
  */
 function setup_query_vars( array $query_vars ) : array {
 	$query_vars[] = QUERY_VAR;
@@ -39,10 +40,10 @@ function setup_query_vars( array $query_vars ) : array {
 /**
  * Render the Pattern Library
  */
-function template_redirect()  {
-	global $wp_query;
+function template_redirect() {
+	$query_var = get_query_var( QUERY_VAR );
 
-	if ( empty( $wp_query->get( QUERY_VAR ) ) ) {
+	if ( empty( $query_var ) ) {
 		return;
 	}
 

--- a/inc/templates/pattern-library.php
+++ b/inc/templates/pattern-library.php
@@ -12,7 +12,7 @@ $query_var = get_query_var( \Kalutara\Rewrites\QUERY_VAR );
 // Build list of template files to display.
 // Either a single template or find all.
 if ( $query_var !== 'all' ) {
-	$templates = [ $query_var ];
+	$templates = [ sanitize_text_field( $query_var ) ];
 } else {
 	$template_files = [];
 	$directories[] = get_template_directory() . '/template-parts';
@@ -104,6 +104,11 @@ if ( $query_var !== 'all' ) {
 foreach ( $templates as $template ) :
 	$file_path = locate_template( 'template-parts/' . $template . '.php' );
 	$file_documentation = Kalutara\Parser\get_template_part_header( $file_path );
+
+	if ( empty( $file_path ) ) {
+		continue;
+	}
+
 	?>
 	<article
 		id="kalutara-<?php echo sanitize_html_class( Kalutara\Helpers\get_css_class_name( $template ) ); ?>"

--- a/inc/templates/pattern-library.php
+++ b/inc/templates/pattern-library.php
@@ -14,7 +14,7 @@ $query_var = get_query_var( \Kalutara\Rewrites\QUERY_VAR );
 if ( $query_var !== 'all' ) {
 	$templates = [ sanitize_text_field( $query_var ) ];
 } else {
-	$template_files = [];
+	$templates = [];
 	$directories[] = get_template_directory() . '/template-parts';
 
 	if ( is_child_theme() ) {
@@ -23,11 +23,13 @@ if ( $query_var !== 'all' ) {
 
 	foreach ( $directories as $directory ) {
 		// Convert files in path to template paths.
-		$templates = array_unique( array_map(
+		$templates = array_merge( $templates, array_map(
 			'\Kalutara\Helpers\remove_extension_from_filename',
 			Kalutara\Helpers\get_files_in_path( $directory )
 		) );
 	}
+
+	$templates = array_unique( $templates );
 }
 
 ?>


### PR DESCRIPTION
The rewrite rules are set up to allow passing a single pattern but this is not yet functional. This PR makes it work. 

So you should be able to visit a URL like `pattern-library/button` or `pattern-library/components/nav` to view only that pattern.  The path used needs to be the path relative to the `template-parts` directory.